### PR TITLE
compress the jinbe before release it

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,9 @@ mkdir _
 deno compile -A -r --unstable --target x86_64-unknown-linux-gnu -o _/jinbe_linux_amd64 https://raw.githubusercontent.com/txthinking/jinbe/master/main.js
 deno compile -A -r --unstable --target x86_64-apple-darwin -o _/jinbe_darwin_amd64 https://raw.githubusercontent.com/txthinking/jinbe/master/main.js
 
+#install upx first
+upx _/*
+
 nami release github.com/txthinking/jinbe $1 _
 
 rm -rf _


### PR DESCRIPTION
because the release is too big, more than 50MB. After using upx , the size is only 17MB.
Fix #3 